### PR TITLE
script: use baseurl instead of mirrorlist in centos7 docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,18 @@
 FROM centos:7
 
+# use baseurl instead of mirrorlist
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+RUN yum clean all && yum makecache
+
 RUN yum install -y centos-release-scl
+# use baseurl instead of mirrorlist in CentOS-SCLo-scl.repo
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+RUN yum clean all && yum makecache
+
 RUN yum install -y git dtc devtoolset-11 llvm-toolset-7 bison flex
 RUN echo "source /opt/rh/devtoolset-11/enable" >> /etc/profile
 RUN echo "source /opt/rh/llvm-toolset-7/enable" >> /etc/profile


### PR DESCRIPTION
On July 1, 2024, CentOS 7 reached end of life, and the CentOS team has moved its repositories to the archive at vault.centos.org. Without updating the repository URLs, packages cannot be updated or validated, resulting in these errors.